### PR TITLE
Accept floats without leading zero.

### DIFF
--- a/src/regexes.coffee
+++ b/src/regexes.coffee
@@ -1,5 +1,5 @@
 int = '\\d+'
-float = "#{int}(?:\\.#{int})?"
+float = "\\d*(?:\\.#{int})?"
 percent = "#{float}%"
 
 module.exports =


### PR DESCRIPTION
Floats may begin with a dot.
This failed parsing `rgba(1, 2, 3, .123)`.
